### PR TITLE
Feature: stake pool versioning and reserved space for upgrades

### DIFF
--- a/clients/js-legacy/src/layouts.ts
+++ b/clients/js-legacy/src/layouts.ts
@@ -161,6 +161,7 @@ export interface StakePool {
 }
 
 export const StakePoolLayout = struct<StakePool>([
+  u8('version'),
   u8('accountType'),
   publicKey('manager'),
   publicKey('staker'),

--- a/clients/py/stake_pool/state.py
+++ b/clients/py/stake_pool/state.py
@@ -188,6 +188,7 @@ FEE_LAYOUT = Struct(
 )
 
 STAKE_POOL_LAYOUT = Struct(
+    "version" / Int8ul,
     "account_type" / Int8ul,
     "manager" / PUBLIC_KEY_LAYOUT,
     "staker" / PUBLIC_KEY_LAYOUT,
@@ -228,6 +229,7 @@ STAKE_POOL_LAYOUT = Struct(
 )
 
 DECODE_STAKE_POOL_LAYOUT = Struct(
+    "version" / Int8ul,
     "account_type" / Int8ul,
     "manager" / PUBLIC_KEY_LAYOUT,
     "staker" / PUBLIC_KEY_LAYOUT,

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -855,6 +855,7 @@ impl Processor {
             &validator_list,
         )?;
 
+        stake_pool.version = 1;
         stake_pool.account_type = AccountType::StakePool;
         stake_pool.manager = *manager_info.key;
         stake_pool.staker = *staker_info.key;
@@ -883,6 +884,7 @@ impl Processor {
         stake_pool.next_sol_withdrawal_fee = FutureEpoch::None;
         stake_pool.last_epoch_pool_token_supply = 0;
         stake_pool.last_epoch_total_lamports = 0;
+        stake_pool._reserved = [0; 256];
 
         borsh::to_writer(&mut stake_pool_info.data.borrow_mut()[..], &stake_pool)
             .map_err(|e| e.into())

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -41,8 +41,11 @@ pub enum AccountType {
 
 /// Initialized program details.
 #[repr(C)]
-#[derive(Clone, Debug, Default, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct StakePool {
+    /// Version of the stake pool program. This allows for future upgrades.
+    pub version: u8,
+
     /// Account type, must be `StakePool` currently
     pub account_type: AccountType,
 
@@ -156,7 +159,50 @@ pub struct StakePool {
 
     /// Last epoch's total lamports, used only for APR estimation
     pub last_epoch_total_lamports: u64,
+
+    /// Reserved space for future use
+    pub _reserved: [u8; 256],
 }
+
+impl Default for StakePool {
+    fn default() -> Self {
+        Self {
+            version: 1,
+            account_type: AccountType::StakePool,
+            manager: Pubkey::default(),
+            staker: Pubkey::default(),
+            stake_deposit_authority: Pubkey::default(),
+            stake_withdraw_bump_seed: 0,
+            validator_list: Pubkey::default(),
+            reserve_stake: Pubkey::default(),
+            pool_mint: Pubkey::default(),
+            manager_fee_account: Pubkey::default(),
+            token_program_id: Pubkey::default(),
+            total_lamports: 0,
+            pool_token_supply: 0,
+            last_update_epoch: 0,
+            lockup: Lockup::default(),
+            epoch_fee: Fee::default(),
+            next_epoch_fee: FutureEpoch::None,
+            preferred_deposit_validator_vote_address: None,
+            preferred_withdraw_validator_vote_address: None,
+            stake_deposit_fee: Fee::default(),
+            stake_withdrawal_fee: Fee::default(),
+            next_stake_withdrawal_fee: FutureEpoch::None,
+            stake_referral_fee: 0,
+            sol_deposit_authority: None,
+            sol_deposit_fee: Fee::default(),
+            sol_referral_fee: 0,
+            sol_withdraw_authority: None,
+            sol_withdrawal_fee: Fee::default(),
+            next_sol_withdrawal_fee: FutureEpoch::None,
+            last_epoch_pool_token_supply: 0,
+            last_epoch_total_lamports: 0,
+            _reserved: [0; 256],
+        }
+    }
+}
+
 impl StakePool {
     /// calculate the pool tokens that should be minted for a deposit of
     /// `stake_lamports`


### PR DESCRIPTION
- Add version field to StakePool struct for future upgrades
- Increase reserved space to 256 bytes for future fields
- Rename reserved field to _reserved to indicate it's private
- Initialize version to 1 in process_initialize
- Add custom Default implementation with version = 1