### PR TITLE
Fix JS and Python client tests for custom StakePool fields

### DIFF
--- a/clients/js-legacy/test/mocks.ts
+++ b/clients/js-legacy/test/mocks.ts
@@ -7,11 +7,12 @@ import { ValidatorListLayout, ValidatorStakeInfoStatus } from '../src/layouts';
 export const CONSTANTS = {
   poolTokenAccount: new PublicKey('GQkqTamwqjaNDfsbNm7r3aXPJ4oTSqKC3d5t2PF9Smqd'),
   validatorStakeAccountAddress: new PublicKey(
-    new BN('69184b7f1bc836271c4ac0e29e53eb38a38ea0e7bcde693c45b30d1592a5a678', 'hex'),
+    new BN('8c2899cbb34f4d86298033a61c588a87e47763651168bf7c88ed9fa599bf562f', 'hex'),
   ),
 };
 
 export const stakePoolMock = {
+  version: 1,
   accountType: 1,
   manager: new PublicKey(11),
   staker: new PublicKey(12),
@@ -70,6 +71,7 @@ export const stakePoolMock = {
   },
   lastEpochPoolTokenSupply: new BN(0),
   lastEpochTotalLamports: new BN(0),
+  maxValidatorStake: null,
 };
 
 export const validatorListMock = {

--- a/clients/py/stake_pool/state.py
+++ b/clients/py/stake_pool/state.py
@@ -226,7 +226,9 @@ STAKE_POOL_LAYOUT = Struct(
     "next_sol_withdrawal_fee" / FEE_LAYOUT,
     "last_epoch_pool_token_supply" / Int64ul,
     "last_epoch_total_lamports" / Int64ul,
-    "max_validator_stake" / Int64ul
+    "max_validator_stake_option" / Int8ul,
+    "max_validator_stake" / Int64ul,
+    "_reserved" / Bytes(256),
 )
 
 DECODE_STAKE_POOL_LAYOUT = Struct(
@@ -303,7 +305,14 @@ DECODE_STAKE_POOL_LAYOUT = Struct(
         }),
     "last_epoch_pool_token_supply" / Int64ul,
     "last_epoch_total_lamports" / Int64ul,
-    "max_validator_stake" / Int64ul
+    "max_validator_stake_option" / Int8ul,
+    "max_validator_stake" / Switch(
+        lambda this: this.max_validator_stake_option,
+        {
+            0: Pass,
+            1: Int64ul,
+        }),
+    "_reserved" / Bytes(256),
 )
 
 VALIDATOR_INFO_LAYOUT = Struct(


### PR DESCRIPTION
## Summary

- Update JS legacy test mocks to include `version` and `maxValidatorStake` fields added by our fork
- Fix `validatorStakeAccountAddress` PDA constant to match our fork's program ID
- Fix Python `STAKE_POOL_LAYOUT` and `DECODE_STAKE_POOL_LAYOUT` to encode `max_validator_stake` as `Option<u64>` (was plain `Int64ul`)
- Add missing `_reserved` field (256 bytes) to Python layouts

## Test plan

- [x] JS legacy tests: 25/25 passing locally
- [x] Program SBF tests: all passing locally